### PR TITLE
revisions

### DIFF
--- a/src/tradetestlib/evaluation.py
+++ b/src/tradetestlib/evaluation.py
@@ -171,9 +171,6 @@ class Evaluation:
     commission_composition:
         average percentage of commission to average profitable trades
         
-    signal_accuracy:
-        signal accuracy to true signal
-        
         
     """
     def __init__(self, data: pd.DataFrame, hyperparameters: dict):
@@ -246,7 +243,7 @@ class Evaluation:
         
         # Periodic Return (for calculating sharpe ratio)
         self.daily_return = self.net_profit_pct / days
-        self.monthly_return = self.net_profit_pct / days / 30
+        self.monthly_return = self.daily_return * 30
         
         # Order statistics (long and short), amount, and performance
         self.long_positions = data.loc[(long_signal_mask) & (data['net_profit'] != 0)]['net_profit'].count()
@@ -277,16 +274,10 @@ class Evaluation:
         # Commission composition: Percentage lost due to transaction costs
         self.commission_composition = ((data['commission'].max()*2) / self.avg_win_usd) * 100
         
-        # Signal accuracy
-        to_test = data.loc[data['signal'] != 0]
-        all_signals = to_test['match'].count()
-        match_count = to_test[to_test['match'] == 1]['match'].count()
-        self.signal_accuracy = (match_count / all_signals) * 100
         
         self.evaluation_data = {
             'start_date' : self.start_date, 
             'end_date' : self.end_date, 
-            'signal_accuracy' : self.signal_accuracy, 
             'starting_balance' : self.starting_balance, 
             'end_balance' : self.end_balance, 
             'mean_profit_points' : self.mean_profit_points, 

--- a/src/tradetestlib/mt5_data.py
+++ b/src/tradetestlib/mt5_data.py
@@ -7,6 +7,7 @@ from datetime import datetime as dt, timedelta
 class MT5_Data:
     
     def __init__(self):
+        
         if mt5.account_info() is None:
             print('Launching MT5')
             self.launch_mt5()
@@ -15,9 +16,16 @@ class MT5_Data:
         if not mt5.initialize('C:/Program Files/MetaTrader 5 IC Markets (SC)/terminal64.exe'):
             return False
         else:
+            print('MT5 Launched')
             return True
 
-    def request_price_data(self, symbol: str, tf: str, start_date = None, end_date = None, export: bool = False):
+    def request_price_data(self, symbol: str, 
+                           tf: str, 
+                           request_type:str = 'pos', 
+                           start_date = None, end_date = None, 
+                           start_index: int = 0, 
+                           num_bars:int = 99000, 
+                           export: bool = False):
         """
         Requests price data from MT5, and exports to csv
         
@@ -28,7 +36,40 @@ class MT5_Data:
             
         tf: str
             Timeframe
-            
+
+        request_type: str
+            Default: 'pos'
+
+            option for requesting data from mt5 (pos, date, range)
+
+            pos - fetch based on position
+            date - fetch based on start date
+            range - fetch based on date range
+
+        start_date: dt
+			Default: None
+
+			start date for requesting data from mt5. used when selecting
+			'date' or 'rates' as request_type.
+
+		end_date: dt
+			Default: None
+
+			end date for requesting data from mt5. used when 'rates' is 
+			selected as request_type
+
+		start_index: int
+			Default: 0
+
+			start index for requesting data from mt5. used when 'pos' is 
+			selected as request_type
+		
+		num_bars: int
+			Default: 99000
+
+			number of bars to receive. used when selecting 'pos' or 'date'
+			as request_type.
+
         Returns
         -------
         data: pd.DataFrame
@@ -46,10 +87,19 @@ class MT5_Data:
             'mn1' : mt5.TIMEFRAME_MN1,
         }
         
-        now_date = dt.now() - timedelta(days = 1)
-        ref_date = dt(now_date.year, now_date.month, now_date.day, 7, 59, 59)
+        if request_type == 'pos':
+            rates = mt5.copy_rates_from_pos(symbol, timeframe_converter[tf], start_index, num_bars)
+
+        elif request_type == 'date':
+            rates = mt5.copy_rates_from(symbol, timeframe_converter[tf], start_date, num_bars)
+
+        elif request_type == 'range':
+            rates = mt5.copy_rates_range(symbol, timeframe_converter[tf], start_date, end_date)
         
-        rates = mt5.copy_rates_from(symbol, timeframe_converter[tf], ref_date, 99000)
+        else: 
+            raise ValueError('Invalid Request')
+        
+
         #rates = mt5.copy_rates_from_pos(symbol, timeframe_converter[tf], 1, 99000)
         data = pd.DataFrame(data = rates)
         data['time'] = pd.to_datetime(data['time'], unit = 's')

--- a/src/tradetestlib/optimize.py
+++ b/src/tradetestlib/optimize.py
@@ -1,7 +1,7 @@
 import pandas as pd 
 import numpy as np 
 from tradetestlib.simulation import Simulation
-from tqdm import tqdm
+from tqdm import tqdm 
 from itertools import product 
 
 class Optimize:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,9 @@ from src.tradetestlib import *
 def sim():
     symbol = 'CHFSGD'
     tf = 'm5'
-    train_data = pd.read_csv('./tradetestlib/tests/train.csv', index_col = 'time')
+    train_data = pd.read_csv('./tests/train.csv', index_col = 'time')
     train_data.index = pd.to_datetime(train_data.index)
-    test_data = pd.read_csv('./tradetestlib/tests/test.csv', index_col = 'time')
+    test_data = pd.read_csv('./tests/test.csv', index_col = 'time')
     test_data.index = pd.to_datetime(test_data.index)
 
     return Simulation(symbol = symbol,


### PR DESCRIPTION
Evaluations: 
1. removed `signal_accuracy`

MT5_Data
1. revised `request_price_data`

Simulation
1. created `filter_default()` method - for grouping with higher time frames
2. set `max_loss_pct` default to 1
3. added `num_elements` for interval filtering
4. `best_interval_by_cost_delta` now only returns top n best results defined by `num_elements` 
5. created provision for interval filtering for higher timeframes 
6. removed `true_signal` column 
7. revised calculation of `tradediff`
8. revised requesting method for mt5 data (contract size, tick size, etc) 

Tests
1. revised csv path
