### PR TITLE
rev

### DIFF
--- a/src/tradetestlib/optimize.py
+++ b/src/tradetestlib/optimize.py
@@ -39,17 +39,22 @@ class Optimize:
                  timeframe: str, 
                  train: pd.DataFrame, 
                  test: pd.DataFrame,
+                 starting_balance: 100000,
                  metric: str = 'sharpe_ratio', 
                  how: str = 'maximize', 
-                 dataset: str = 'train'):
+                 dataset: str = 'train',
+                 show_properties: str = False):
         self.symbol = symbol
         self.timeframe = timeframe
         self.train = train
         self.test = test
+        self.starting_balance = starting_balance
         self.metric = metric
         self.how = how
         self.dataset = dataset
-        self.print_optimization_parameters()
+        self.show_properties = show_properties
+        if self.show_properties:
+            self.print_optimization_parameters()
         
     def print_optimization_parameters(self):
         """
@@ -59,6 +64,7 @@ class Optimize:
         print('========== OPTIMIZATION PARAMETERS ==========')
         print('Symbol: ', self.symbol)
         print('Timeframe: ', self.timeframe)
+        print('Starting Balance: ', self.starting_balance)
         print('Metric: ', self.metric)
         print('Target: ', self.how)
         print('Optimization Method: Grid Search')
@@ -81,22 +87,24 @@ class Optimize:
         -------
         optimized_parameters
         """
-        print('Lots: ', params['lot'])
-        print('Hold Time: ', params['hold_time'])
-        print('Max Loss: ', params['max_loss'])
-        print('========== RUNNING OPTIMIZATION ==========')
+        if self.show_properties:
+            print('Lots: ', params['lot'])
+            print('Hold Time: ', params['hold_time'])
+            print('Max Loss: ', params['max_loss'])
+            print('========== RUNNING OPTIMIZATION ==========')
         sim_elements = []
         summaries = []
         sims = []
         for l,h,m in tqdm(product(params['lot'], params['hold_time'],params['max_loss'])):
             sim = Simulation(symbol = self.symbol, timeframe = self.timeframe, train_raw = self.train, test_raw = self.test, 
                              lot = l, 
-                             starting_balance = 100000, 
+                             starting_balance = self.starting_balance, 
                              hold_time = h, 
                              #trading_hours = th, 
                              show_properties = False,
                              commission = 3.5,
-                             max_loss_pct = m)
+                             max_loss_pct = m,
+                             spread = 1)
             
             if self.dataset == 'combined':
                 data = sim.combined_summary


### PR DESCRIPTION
Evaluation:
- spread type changed
- median p/l usd added
- returns volatility added
- annual returns added
- sharpe ratio corrected

MT5_Data:
- wrapped main request block in try-except
- added spread to columns

Optimize:
- added starting balance
- added show_properties

Simulation:
- added option for manually simulating different spreads (stress test)
- added exclude_time and trade_time: time string in format HH:SS to exclude from trading, or to allow trading
- trading_window_start and trading_window_end added: filters trades outside this window.
